### PR TITLE
Escape values containing windows newline

### DIFF
--- a/src/dsv.js
+++ b/src/dsv.js
@@ -28,7 +28,7 @@ function inferColumns(rows) {
 }
 
 export default function(delimiter) {
-  var reFormat = new RegExp("[\"" + delimiter + "\n]"),
+  var reFormat = new RegExp("[\"" + delimiter + "\n\r]"),
       delimiterCode = delimiter.charCodeAt(0);
 
   function parse(text, f) {

--- a/test/csv-test.js
+++ b/test/csv-test.js
@@ -192,6 +192,11 @@ tape("csvFormatRows(array) escapes Unix newlines", function(test) {
   test.end();
 });
 
+tape("csvFormatRows(array) escapes Windows newlines", function(test) {
+  test.deepEqual(dsv.csvFormatRows([["new\rline"]]), "\"new\rline\"");
+  test.end();
+});
+
 tape("csvFormatRows(array) escapes values containing delimiters", function(test) {
   test.deepEqual(dsv.csvFormatRows([["oxford,comma"]]), "\"oxford,comma\"");
   test.end();

--- a/test/dsv-test.js
+++ b/test/dsv-test.js
@@ -174,6 +174,11 @@ tape("dsv(\"|\").formatRows(array) escapes Unix newlines", function(test) {
   test.end();
 });
 
+tape("dsv(\"|\").formatRows(array) escapes Windows newlines", function(test) {
+  test.deepEqual(psv.formatRows([["new\rline"]]), "\"new\rline\"");
+  test.end();
+});
+
 tape("dsv(\"|\").formatRows(array) escapes values containing delimiters", function(test) {
   test.deepEqual(psv.formatRows([["oxford|tab"]]), "\"oxford|tab\"");
   test.end();

--- a/test/tsv-test.js
+++ b/test/tsv-test.js
@@ -172,6 +172,11 @@ tape("tsvFormatRows(array) escapes Unix newlines", function(test) {
   test.end();
 });
 
+tape("tsvFormatRows(array) escapes Windows newlines", function(test) {
+  test.deepEqual(dsv.tsvFormatRows([["new\rline"]]), "\"new\rline\"");
+  test.end();
+});
+
 tape("tsvFormatRows(array) escapes values containing delimiters", function(test) {
   test.deepEqual(dsv.tsvFormatRows([["oxford\ttab"]]), "\"oxford\ttab\"");
   test.end();


### PR DESCRIPTION
When value contains \r without \n it should be escaped. Otherwise the CSV is broken in some programs (like excel).