### PR TITLE
Set Rollup's options.extend to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/d3/d3-dsv.git"
   },
   "scripts": {
-    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -n d3 -o build/d3-dsv.js -- index.js",
+    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -n d3 --extend -o build/d3-dsv.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src",
     "prepublish": "npm run test && uglifyjs -b beautify=false,preamble=\"'$(preamble)'\" build/d3-dsv.js -c -m -o build/d3-dsv.min.js",
     "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-dsv/build/d3-dsv.js d3-dsv.v1.js && cp ../d3-dsv/build/d3-dsv.min.js d3-dsv.v1.min.js && git add d3-dsv.v1.js d3-dsv.v1.min.js && git commit -m \"d3-dsv ${npm_package_version}\" && git push && cd - && zip -j build/d3-dsv.zip -- LICENSE README.md build/d3-dsv.js build/d3-dsv.min.js"


### PR DESCRIPTION
Fixes #29.

Verified locally that with this change we get the desired output:

```js
// https://d3js.org/d3-dsv/ Version 1.0.6. Copyright 2017 Mike Bostock.
(function (global, factory) {
  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports
  typeof define === 'function' && define.amd ? define(['exports'], factory) :
  (factory((global.d3 = global.d3 || {})));  <------------------ This is what we want.
}(this, (function (exports) { 'use strict';
```