### PR TITLE
Initialize column property in xxxParse(...) to empty array

### DIFF
--- a/src/dsv.js
+++ b/src/dsv.js
@@ -38,7 +38,7 @@ export default function(delimiter) {
       DELIMITER = delimiter.charCodeAt(0);
 
   function parse(text, f) {
-    var convert, columns, rows = parseRows(text, function(row, i) {
+    var convert, columns = [], rows = parseRows(text, function(row, i) {
       if (convert) return convert(row, i - 1);
       columns = row, convert = f ? customConverter(row, f) : objectConverter(row);
     });

--- a/src/dsv.js
+++ b/src/dsv.js
@@ -38,11 +38,11 @@ export default function(delimiter) {
       DELIMITER = delimiter.charCodeAt(0);
 
   function parse(text, f) {
-    var convert, columns = [], rows = parseRows(text, function(row, i) {
+    var convert, columns, rows = parseRows(text, function(row, i) {
       if (convert) return convert(row, i - 1);
       columns = row, convert = f ? customConverter(row, f) : objectConverter(row);
     });
-    rows.columns = columns;
+    rows.columns = columns || [];
     return rows;
   }
 


### PR DESCRIPTION
* Closes #31.

This suggested initialization addresses the case, where [the mapping function of parseRows(...) in L41](https://github.com/d3/d3-dsv/blob/22131977a6a36f08c7cbfcbd7d926838a8177d7f/src/dsv.js#L41) is never invoked (edge case of parsing empty string).