### PR TITLE
Incorrect decoding of local dates in Safari.

### DIFF
--- a/src/autoType.js
+++ b/src/autoType.js
@@ -1,4 +1,8 @@
 export default function autoType(object) {
+  var m,
+    tzFix = (new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours())
+      ? new Date().getTimezoneOffset() * 60000
+      : false;
   for (var key in object) {
     var value = object[key].trim(), number;
     if (!value) value = null;
@@ -6,7 +10,10 @@ export default function autoType(object) {
     else if (value === "false") value = false;
     else if (value === "NaN") value = NaN;
     else if (!isNaN(number = +value)) value = number;
-    else if (/^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)) value = new Date(value);
+    else if (m = value.match(/^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/)) {
+      value = new Date(value);
+      if (tzFix && !m[7]) value = new Date(+value + tzFix);
+    }
     else continue;
     object[key] = value;
   }

--- a/src/autoType.js
+++ b/src/autoType.js
@@ -1,21 +1,32 @@
 export default function autoType(object) {
-  var m,
-    tzFix = (new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours())
-      ? new Date().getTimezoneOffset() * 60000
-      : false;
   for (var key in object) {
-    var value = object[key].trim(), number;
+    var value = object[key].trim(), number, m;
     if (!value) value = null;
     else if (value === "true") value = true;
     else if (value === "false") value = false;
     else if (value === "NaN") value = NaN;
     else if (!isNaN(number = +value)) value = number;
     else if (m = value.match(/^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/)) {
+      if (fixtz && !!m[4] && !m[7]) value += fixtz;
       value = new Date(value);
-      if (tzFix && !m[7]) value = new Date(+value + tzFix);
     }
     else continue;
     object[key] = value;
   }
   return object;
+}
+
+// https://github.com/d3/d3-dsv/issues/45
+var fixtz = tzoffset();
+
+function tzoffset() {
+  if (new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours()) {
+    var offset = -new Date().getTimezoneOffset() / 60;
+    return (
+        offset < -9 ? "-" + -offset
+      : offset < 0 ? "-0" + -offset
+      : offset < 10 ? "+0" + offset
+      : "+" + offset
+    ) + ":00";
+  }
 }

--- a/src/autoType.js
+++ b/src/autoType.js
@@ -6,8 +6,8 @@ export default function autoType(object) {
     else if (value === "false") value = false;
     else if (value === "NaN") value = NaN;
     else if (!isNaN(number = +value)) value = number;
-    else if (m = value.match(/^([-+]\d{2})?(\d{4}(-\d{2}(-\d{2})?)?)(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/)) {
-      if (fixtz && !!m[5] && !m[8]) value += tzoffset(m[2]);
+    else if (m = value.match(/^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/)) {
+      if (fixtz && !!m[4] && !m[7]) value = value.replace(/-/g, "/").replace(/T/, " ");
       value = new Date(value);
     }
     else continue;
@@ -18,13 +18,3 @@ export default function autoType(object) {
 
 // https://github.com/d3/d3-dsv/issues/45
 var fixtz = new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours();
-
-function tzoffset(day) {
-  var offset = -new Date(day).getTimezoneOffset() / 60;
-  return (
-      offset < -9 ? "-" + -offset
-    : offset < 0 ? "-0" + -offset
-    : offset < 10 ? "+0" + offset
-    : "+" + offset
-  ) + ":00";
-}

--- a/src/autoType.js
+++ b/src/autoType.js
@@ -6,8 +6,8 @@ export default function autoType(object) {
     else if (value === "false") value = false;
     else if (value === "NaN") value = NaN;
     else if (!isNaN(number = +value)) value = number;
-    else if (m = value.match(/^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/)) {
-      if (fixtz && !!m[4] && !m[7]) value += fixtz;
+    else if (m = value.match(/^([-+]\d{2})?(\d{4}(-\d{2}(-\d{2})?)?)(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/)) {
+      if (fixtz && !!m[5] && !m[8]) value += tzoffset(m[2]);
       value = new Date(value);
     }
     else continue;
@@ -17,16 +17,14 @@ export default function autoType(object) {
 }
 
 // https://github.com/d3/d3-dsv/issues/45
-var fixtz = tzoffset();
+var fixtz = new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours();
 
-function tzoffset() {
-  if (new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours()) {
-    var offset = -new Date().getTimezoneOffset() / 60;
-    return (
-        offset < -9 ? "-" + -offset
-      : offset < 0 ? "-0" + -offset
-      : offset < 10 ? "+0" + offset
-      : "+" + offset
-    ) + ":00";
-  }
+function tzoffset(day) {
+  var offset = -new Date(day).getTimezoneOffset() / 60;
+  return (
+      offset < -9 ? "-" + -offset
+    : offset < 0 ? "-0" + -offset
+    : offset < 10 ? "+0" + offset
+    : "+" + offset
+  ) + ":00";
 }


### PR DESCRIPTION
instead of treating `new Date("2018-04-25T11:00")` as a local date, Safari parses it as a UTC date and returns it with the tz difference added. This fix detects the situation by checking TWO local dates (one in winter, one in summer) which should return hour 0, and if one of them is not 0 it's the Safari bug. In that case, and if the date string that is passed is local (no "Z"), we shift it accordingly.

I don't know how to write a node test for this, but the following notebook shows the fix on Safari:
https://observablehq.com/d/7e8b78e5050258ae

Fixes https://github.com/d3/d3-dsv/issues/45