### PR TITLE
Return empty string for missing columns, instead of undefined

### DIFF
--- a/src/dsv.js
+++ b/src/dsv.js
@@ -6,7 +6,7 @@ var EOL = {},
 
 function objectConverter(columns) {
   return new Function("d", "return {" + columns.map(function(name, i) {
-    return JSON.stringify(name) + ": d[" + i + "]";
+    return JSON.stringify(name) + ": d[" + i + "] || \"\"";
   }).join(",") + "}");
 }
 

--- a/test/csv-test.js
+++ b/test/csv-test.js
@@ -47,17 +47,17 @@ tape("csvParse(string) ignores a blank last line", function(test) {
 });
 
 tape("csvParse(string) treats a blank non-last line as a single-column empty string", function(test) {
-  test.deepEqual(dsv.csvParse("a,b,c\n1,2,3\n\n"), table([{a: "1", b: "2", c: "3"}, {a: "", b: undefined, c: undefined}], ["a", "b", "c"]));
+  test.deepEqual(dsv.csvParse("a,b,c\n1,2,3\n\n"), table([{a: "1", b: "2", c: "3"}, {a: "", b: "", c: ""}], ["a", "b", "c"]));
   test.end();
 });
 
-tape("csvParse(string) returns undefined values for missing columns", function(test) {
-  test.deepEqual(dsv.csvParse("a,b,c\n1\n1,2"), table([{a: "1", b: undefined, c: undefined}, {a: "1", b: "2", c: undefined}], ["a", "b", "c"]));
+tape("csvParse(string) returns empty strings for missing columns", function(test) {
+  test.deepEqual(dsv.csvParse("a,b,c\n1\n1,2"), table([{a: "1", b: "", c: ""}, {a: "1", b: "2", c: ""}], ["a", "b", "c"]));
   test.end();
 });
 
 tape("csvParse(string) does not ignore a whitespace-only last line", function(test) {
-  test.deepEqual(dsv.csvParse("a,b,c\n1,2,3\n "), table([{a: "1", b: "2", c: "3"}, {a: " ", b: undefined, c: undefined}], ["a", "b", "c"]));
+  test.deepEqual(dsv.csvParse("a,b,c\n1,2,3\n "), table([{a: "1", b: "2", c: "3"}, {a: " ", b: "", c: ""}], ["a", "b", "c"]));
   test.end();
 });
 


### PR DESCRIPTION
Reverses one test, so technically we can say that it breaks the API. However README is silent about this situation, so I don't know.

Fixes https://github.com/d3/d3-dsv/issues/48