### PR TITLE
Use RFC3339 date string format in fixtz Date constructor

### DIFF
--- a/src/autoType.js
+++ b/src/autoType.js
@@ -17,4 +17,6 @@ export default function autoType(object) {
 }
 
 // https://github.com/d3/d3-dsv/issues/45
-var fixtz = new Date("2019-01-01T00:00").getHours() || new Date("2019-07-01T00:00").getHours();
+var fixtz =
+  new Date("2019-01-01T00:00:00").getHours() ||
+  new Date("2019-07-01T00:00:00").getHours();


### PR DESCRIPTION
After the latest version bump to D3@5.14.1, some of my tests started to fail with the following error from timezone-mock, which I use to mock UTC for my tests.

```
AssertionError [ERR_ASSERTION]: Unhandled date format passed to MockDate constructor: 2019-01-01T00:00
```

https://github.com/Jimbly/timezone-mock/blob/ffe306c2/index.js#L33

Turns out "2019-01-01T00:00" is not an RFC3339 format. This PR adds the seconds precision to this date string so it matches spec.
