### PR TITLE
dsv2json: Add '-a/--autotype' flag to use d3.autoType

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,11 @@ Output the version number.
 
 Specify the output file name. Defaults to “-” for stdout.
 
+<a name="dsv2json_autotype" href="dsv2json_autotype">#</a> dsv2json <b>-a</b>
+<br><a href="dsv2json_autotype">#</a> dsv2json <b>--autotype</b>
+
+Use type inference when parsing rows. See <a href="#autoType">d3.autoType</a> for how it works.
+
 <a name="dsv2json_input_delimiter" href="dsv2json_input_delimiter">#</a> dsv2json <b>-r</b> <i>delimiter</i>
 <br><a href="dsv2json_input_delimiter">#</a> dsv2json <b>--input-delimiter</b> <i>delimiter</i>
 

--- a/bin/dsv2json
+++ b/bin/dsv2json
@@ -15,6 +15,7 @@ commander
     .usage("[options] [file]")
     .option("-o, --out <file>", "output file name; defaults to “-” for stdout", "-")
     .option("-r, --input-delimiter <character>", "input delimiter character", defaultInDelimiter)
+    .option("-a, --autotype", "parse rows with type inference (see d3.autoType)")
     .option("-n, --newline-delimited", "output newline-delimited JSON")
     .option("--input-encoding <encoding>", "input character encoding; defaults to “utf8”", "utf8")
     .option("--output-encoding <encoding>", "output character encoding; defaults to “utf8”", "utf8")
@@ -24,7 +25,10 @@ var inFormat = dsv.dsvFormat(commander.inputDelimiter);
 
 rw.readFile(commander.args[0] || "-", function(error, text) {
   if (error) throw error;
-  var rows = inFormat.parse(iconv.decode(text, commander.inputEncoding));
+
+  var rowConverter = commander.autotype ? dsv.autoType : null
+  var rows = inFormat.parse(iconv.decode(text, commander.inputEncoding), rowConverter);
+
   rw.writeFile(commander.out, iconv.encode(commander.newlineDelimited
       ? rows.map(function(row) { return JSON.stringify(row); }).join("\n") + "\n"
       : JSON.stringify(rows) + os.EOL, commander.outputEncoding), function(error) {


### PR DESCRIPTION
It was a need I had converting some files, seemed straightforward enough.

I'm thinking we don't want to make this the default for now.