### PR TITLE
Add a CSP warning for csvParse, tsvParse, parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Equivalent to [dsvFormat](#dsvFormat)("\t").[formatValue](#dsv_formatValue).
 
 Constructs a new DSV parser and formatter for the specified *delimiter*. The *delimiter* must be a single character (*i.e.*, a single 16-bit code unit); so, ASCII delimiters are fine, but emoji delimiters are not.
 
-<a name="dsv_parse" href="#dsv_parse">#</a> *dsv*.<b>parse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/dsv.js "Source") :warning: [CSP in browser context](#content-security-policy)
+<a name="dsv_parse" href="#dsv_parse">#</a> *dsv*.<b>parse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/dsv.js "Source")
 
 Parses the specified *string*, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of objects representing the parsed rows.
 
@@ -146,6 +146,8 @@ var data = d3.csvParse(string, function(d) {
 ```
 
 Note: using `+` rather than [parseInt](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseInt) or [parseFloat](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseFloat) is typically faster, though more restrictive. For example, `"30px"` when coerced using `+` returns `NaN`, while parseInt and parseFloat return `30`.
+
+Note: requires unsafe-eval [content security policy](#content-security-policy).
 
 <a name="dsv_parseRows" href="#dsv_parseRows">#</a> <i>dsv</i>.<b>parseRows</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/dsv.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var data = d3.csvParse(string);
 
 ## API Reference
 
-<a name="csvParse" href="#csvParse">#</a> d3.<b>csvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source")
+<a name="csvParse" href="#csvParse">#</a> d3.<b>csvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source") :warning: [CSP in browser context](#content-security-policy)
 
 Equivalent to [dsvFormat](#dsvFormat)(",").[parse](#dsv_parse).
 
@@ -71,7 +71,7 @@ Equivalent to [dsvFormat](#dsvFormat)(",").[formatRow](#dsv_formatRow).
 
 Equivalent to [dsvFormat](#dsvFormat)(",").[formatValue](#dsv_formatValue).
 
-<a name="tsvParse" href="#tsvParse">#</a> d3.<b>tsvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source")
+<a name="tsvParse" href="#tsvParse">#</a> d3.<b>tsvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source") :warning: [CSP in browser context](#content-security-policy)
 
 Equivalent to [dsvFormat](#dsvFormat)("\t").[parse](#dsv_parse).
 
@@ -103,7 +103,7 @@ Equivalent to [dsvFormat](#dsvFormat)("\t").[formatValue](#dsv_formatValue).
 
 Constructs a new DSV parser and formatter for the specified *delimiter*. The *delimiter* must be a single character (*i.e.*, a single 16-bit code unit); so, ASCII delimiters are fine, but emoji delimiters are not.
 
-<a name="dsv_parse" href="#dsv_parse">#</a> *dsv*.<b>parse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/dsv.js "Source")
+<a name="dsv_parse" href="#dsv_parse">#</a> *dsv*.<b>parse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/dsv.js "Source") :warning: [CSP in browser context](#content-security-policy)
 
 Parses the specified *string*, which must be in the delimiter-separated values format with the appropriate delimiter, returning an array of objects representing the parsed rows.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var data = d3.csvParse(string);
 
 ## API Reference
 
-<a name="csvParse" href="#csvParse">#</a> d3.<b>csvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source") :warning: [CSP in browser context](#content-security-policy)
+<a name="csvParse" href="#csvParse">#</a> d3.<b>csvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source")
 
 Equivalent to [dsvFormat](#dsvFormat)(",").[parse](#dsv_parse). Note: requires unsafe-eval [content security policy](#content-security-policy).
 
@@ -71,7 +71,7 @@ Equivalent to [dsvFormat](#dsvFormat)(",").[formatRow](#dsv_formatRow).
 
 Equivalent to [dsvFormat](#dsvFormat)(",").[formatValue](#dsv_formatValue).
 
-<a name="tsvParse" href="#tsvParse">#</a> d3.<b>tsvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source") :warning: [CSP in browser context](#content-security-policy)
+<a name="tsvParse" href="#tsvParse">#</a> d3.<b>tsvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source")
 
 Equivalent to [dsvFormat](#dsvFormat)("\t").[parse](#dsv_parse). Note: requires unsafe-eval [content security policy](#content-security-policy).
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ var data = d3.csvParse(string);
 
 <a name="csvParse" href="#csvParse">#</a> d3.<b>csvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source") :warning: [CSP in browser context](#content-security-policy)
 
-Equivalent to [dsvFormat](#dsvFormat)(",").[parse](#dsv_parse).
+Equivalent to [dsvFormat](#dsvFormat)(",").[parse](#dsv_parse). Note: requires unsafe-eval [content security policy](#content-security-policy).
 
 <a name="csvParseRows" href="#csvParseRows">#</a> d3.<b>csvParseRows</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source")
 
@@ -73,7 +73,7 @@ Equivalent to [dsvFormat](#dsvFormat)(",").[formatValue](#dsv_formatValue).
 
 <a name="tsvParse" href="#tsvParse">#</a> d3.<b>tsvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source") :warning: [CSP in browser context](#content-security-policy)
 
-Equivalent to [dsvFormat](#dsvFormat)("\t").[parse](#dsv_parse).
+Equivalent to [dsvFormat](#dsvFormat)("\t").[parse](#dsv_parse). Note: requires unsafe-eval [content security policy](#content-security-policy).
 
 <a name="tsvParseRows" href="#tsvParseRows">#</a> d3.<b>tsvParseRows</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source")
 


### PR DESCRIPTION
Fix #66 

Because when coming from the D3 API documentation (https://github.com/d3/d3/blob/master/API.md#delimiter-separated-values-d3-dsv) the "Content Security Policy" warning could be missed.

New visual:

![image](https://user-images.githubusercontent.com/1955774/74664618-591d5a80-519e-11ea-850d-9e0f5b991ed3.png)
