### PR TITLE
Option for skipping comment rows

### DIFF
--- a/src/dsv.js
+++ b/src/dsv.js
@@ -57,7 +57,7 @@ function formatDate(date) {
       : "");
 }
 
-export default function(delimiter) {
+export default function(delimiter, options) {
   var reFormat = new RegExp("[\"" + delimiter + "\n\r]"),
       DELIMITER = delimiter.charCodeAt(0);
 

--- a/test/dsv-test.js
+++ b/test/dsv-test.js
@@ -115,6 +115,18 @@ tape("dsv(\"|\").parseRows(string, row) invokes row(d, i) for each row d, in ord
   test.end();
 });
 
+tape("dsv(\"|\", { comment }).parseRows(string) skips comments", function(test) {
+  test.deepEqual(dsv.dsvFormat("|", { comment: "#" }).parseRows("#blaa\n# blaa\n#\na|#b|c\n1|2|#3\n#blaablaa#\r4|5|\"6\"\r\n#blaa"), [["a", "#b", "c"], ["1", "2", "#3"], ["4", "5", "6"]]);
+  test.deepEqual(dsv.dsvFormat("|", { comment: "//" }).parseRows("//blaa\n// blaa\na|//b|c\n/1|2|//3\n//blaablaa//\n4|5|\"6\"\n//blaa\n"), [["a", "//b", "c"], ["/1", "2", "//3"], ["4", "5", "6"]]);
+  test.end();
+});
+
+tape("dsv(\"|\", { comment }).parse(string) skips comments", function(test) {
+  test.deepEqual(dsv.dsvFormat("|", { comment: "#" }).parse("#blaa\n# blaa\n#\na|#b|c\n1|2|#3\n#blaa"), table([{a: "1", "#b": "2", c: "#3"}], ["a", "#b", "c"]));
+  test.end();
+});
+
+
 tape("dsv(\"|\").format(array) takes an array of objects as input", function(test) {
   test.deepEqual(psv.format([{a: 1, b: 2, c: 3}]), "a|b|c\n1|2|3");
   test.end();


### PR DESCRIPTION
Hi!

Currently, d3-dsv is very pure when it comes to RFC 4180. However, I need some nonstandard but practical features such as skipping comment lines or interpreting NAs as null (for example, in files created with R). Do you accept such pull requests?

So, this draft pull request adds an option object to dsvFormat with a single supported option: `comment`. Example:

```javascript
// Skip all rows that start with a hash character
dsv.dsvFormat("|", { comment: "#" }).parseRows(...)
```