### PR TITLE
Only autoType strings

### DIFF
--- a/src/autoType.js
+++ b/src/autoType.js
@@ -1,5 +1,6 @@
 export default function autoType(object) {
   for (var key in object) {
+    if (typeof object[key] !== "string") continue;
     var value = object[key].trim(), number, m;
     if (!value) value = null;
     else if (value === "true") value = true;


### PR DESCRIPTION
I understand that d3.autoType is somewhat dangerous and only meant to be used in narrow circumstances. But I have still found myself wanting to use it outside the context of d3-dsv, and thus without the guarantee that values will come in as strings. I was happy when `data.map(d3.autoType)` worked (in a case that happened to be all strings), and then surprised when another time it didn't. (I only came across this thanks to @enjalot!)

(Then again, I also actually initially guessed it'd be part of d3-array, and maybe that oughta be warning to me that this is out of scope; maybe if you were writing a more general-purpose autoType, many things would be different.)