### PR TITLE
Refactor to avoid function constructor in the form of eval

### DIFF
--- a/src/dsv.js
+++ b/src/dsv.js
@@ -5,9 +5,13 @@ var EOL = {},
     RETURN = 13;
 
 function objectConverter(columns) {
-  return new Function("d", "return {" + columns.map(function(name, i) {
-    return JSON.stringify(name) + ": d[" + i + "] || \"\"";
-  }).join(",") + "}");
+  return function(d) {
+    var obj = {};
+    for(var k = 0; k < columns.length; k++) {
+      obj[columns[k]] = d[k] || "";
+    }
+    return obj;
+  };
 }
 
 function customConverter(columns, f) {


### PR DESCRIPTION
Seems like this refactor works to avoid security warnings/issues.
Also it would be nice to have a similar patch for d3 v3.
see: https://github.com/archmoj/d3/commit/93e74e544e9332ecbd17b43b3694de511310be6e

cc: @curran @tdelmas https://github.com/d3/d3-dsv/pull/67 https://github.com/d3/d3-dsv/pull/65 
cc: @alexcjohnson @nicolaskruchten https://github.com/plotly/plotly.js/issues/897
