### PR TITLE
Make parse compatible with CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const data = d3.csvParse(string);
 
 <a name="csvParse" href="#csvParse">#</a> d3.<b>csvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source")
 
-Equivalent to [dsvFormat](#dsvFormat)(",").[parse](#dsv_parse). Note: requires unsafe-eval [content security policy](#content-security-policy).
+Equivalent to [dsvFormat](#dsvFormat)(",").[parse](#dsv_parse).
 
 <a name="csvParseRows" href="#csvParseRows">#</a> d3.<b>csvParseRows</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/csv.js "Source")
 
@@ -83,7 +83,7 @@ Equivalent to [dsvFormat](#dsvFormat)(",").[formatValue](#dsv_formatValue).
 
 <a name="tsvParse" href="#tsvParse">#</a> d3.<b>tsvParse</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source")
 
-Equivalent to [dsvFormat](#dsvFormat)("\t").[parse](#dsv_parse). Note: requires unsafe-eval [content security policy](#content-security-policy).
+Equivalent to [dsvFormat](#dsvFormat)("\t").[parse](#dsv_parse).
 
 <a name="tsvParseRows" href="#tsvParseRows">#</a> d3.<b>tsvParseRows</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/tsv.js "Source")
 
@@ -158,8 +158,6 @@ const data = d3.csvParse(string, (d) => {
 ```
 
 Note: using `+` rather than [parseInt](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseInt) or [parseFloat](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseFloat) is typically faster, though more restrictive. For example, `"30px"` when coerced using `+` returns `NaN`, while parseInt and parseFloat return `30`.
-
-Note: requires unsafe-eval [content security policy](#content-security-policy).
 
 <a name="dsv_parseRows" href="#dsv_parseRows">#</a> <i>dsv</i>.<b>parseRows</b>(<i>string</i>[, <i>row</i>]) [<>](https://github.com/d3/d3-dsv/blob/master/src/dsv.js "Source")
 
@@ -302,7 +300,7 @@ For more, see [the d3.autoType notebook](https://observablehq.com/@d3/d3-autotyp
 
 ### Content Security Policy
 
-If a [content security policy](http://www.w3.org/TR/CSP/) is in place, note that [*dsv*.parse](#dsv_parse) requires `unsafe-eval` in the `script-src` directive, due to the (safe) use of dynamic code generation for fast parsing. (See [source](https://github.com/d3/d3-dsv/blob/master/src/dsv.js).) Alternatively, use [*dsv*.parseRows](#dsv_parseRows).
+If a [content security policy](http://www.w3.org/TR/CSP/) without `unsafe-eval` is in place, note that [*dsv*.parse](#dsv_parse) uses a slightly slower code. (See [source](https://github.com/d3/d3-dsv/blob/master/src/dsv.js).) Alternatively, use [*dsv*.parseRows](#dsv_parseRows).
 
 ### Byte-Order Marks
 

--- a/src/dsv.js
+++ b/src/dsv.js
@@ -5,9 +5,19 @@ var EOL = {},
     RETURN = 13;
 
 function objectConverter(columns) {
-  return new Function("d", "return {" + columns.map(function(name, i) {
-    return JSON.stringify(name) + ": d[" + i + "] || \"\"";
-  }).join(",") + "}");
+  try {
+    return new Function("d", "return {" + columns.map(function(name, i) {
+      return JSON.stringify(name) + ": d[" + i + "] || \"\"";
+    }).join(",") + "}");
+  } catch (ex) { // EvalError due to Content Security Policy.
+    return function(d) {
+      var result = {};
+      for (var i = 0; i < columns.length; i++) {
+        result[columns[i]] = d[i] || '';
+      }
+      return result;
+    };
+  }
 }
 
 function customConverter(columns, f) {

--- a/src/dsv.js
+++ b/src/dsv.js
@@ -13,7 +13,7 @@ function objectConverter(columns) {
     return function(d) {
       var result = {};
       for (var i = 0; i < columns.length; i++) {
-        result[columns[i]] = d[i] || '';
+        result[columns[i]] = d[i] || "";
       }
       return result;
     };

--- a/test/dsv-test.js
+++ b/test/dsv-test.js
@@ -157,3 +157,13 @@ it("dsv(\"|\").formatRows(array) escapes values containing delimiters", () => {
 it("dsv(\"|\").formatRow(array) takes a single array of string as input", () => {
   assert.deepStrictEqual(psv.formatRow(["a", "b", "c"]), "a|b|c");
 });
+
+it("dsv(\"|\").parse(string) works with the main branch throwing", () => {
+  const origStringify = JSON.stringify;
+  JSON.stringify = function() {
+    throw new EvalError("test");
+  };
+  assert.deepStrictEqual(psv.parse("a|b|c\n1|2\n"), table([{a: "1", b: "2", c: ""}], ["a", "b", "c"]));
+  assert.deepStrictEqual(psv.parse(readFileSync("test/data/sample.psv", "utf-8")), table([{Hello: "42", World: "\"fish\""}], ["Hello", "World"]));
+  JSON.stringify = origStringify;
+});


### PR DESCRIPTION
Using `parseRows` with CSP enabled is quite cumbersome. I don't see a reason why this shouldn't just work (even though a little slower).