### PR TITLE
Update the parseRows row function description

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The resulting JavaScript array is:
 
 If a *row* conversion function is not specified, field values are strings. For safety, there is no automatic conversion to numbers, dates, or other types. In some cases, JavaScript may coerce strings to numbers for you automatically (for example, using the `+` operator), but better is to specify a *row* conversion function. See [d3.autoType](#autoType) for a convenient *row* conversion function that infers and coerces common types like numbers and strings.
 
-If a *row* conversion function is specified, the specified function is invoked for each row, being passed an array representing the current row (`d`), the index (`i`) starting at zero for the first row, and the array of column names. If the returned value is null or undefined, the row is skipped and will be omitted from the array returned by *dsv*.parse; otherwise, the returned value defines the corresponding row object. For example:
+If a *row* conversion function is specified, the specified function is invoked for each row, being passed an array representing the current row (`d`), the index (`i`) starting at zero for the first row. If the returned value is null or undefined, the row is skipped and will be omitted from the array returned by *dsv*.parse; otherwise, the returned value defines the corresponding row object. For example:
 
 ```js
 const data = d3.csvParseRows(string, (d, i) => {


### PR DESCRIPTION
the row function of dsv.parseRows doesn't have the third parameter, because the dataset pass to dsv.parseRows doesn't have the header row.
but the descriptions say it can receives the the array of column names as the third parameter of row function.